### PR TITLE
Fix typo in mcuconf.h

### DIFF
--- a/keyboards/wob/rd75/mcuconf.h
+++ b/keyboards/wob/rd75/mcuconf.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define ES32_USB_USE_USB0 TURE
+#define ES32_USB_USE_USB0 TRUE
 
 //#include_next <mcuconf.h>
 


### PR DESCRIPTION
Fix typo by replacing `TURE` by `TRUE` 