### PR TITLE
Fix multiple build errors

### DIFF
--- a/keyboards/wob/rd75/config.h
+++ b/keyboards/wob/rd75/config.h
@@ -16,6 +16,11 @@
  */
 #pragma once
 
+/* Size (in bytes) of the emulated EEPROM used by the custom driver. Required 
+ * since QMK assumes no default size when EEPROM_DRIVER=custom (inside rules.mk).
+ */
+#define EEPROM_SIZE 4096
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/wob/rd75/rules.mk
+++ b/keyboards/wob/rd75/rules.mk
@@ -4,9 +4,19 @@
 # Board: it should exist either in <chibios>/os/hal/boards/
 #  or <this_dir>/boards
 BOARD = FS026
-EEPROM_CUSTOM = custom
-NO_USB_STARTUP_CHECK = yes
-BLUETOOTH_CUSTOM = yes
 
-ENCODER_MAP_ENABLE = yes    # Enable ENCODER MAP
-DEBOUNCE_TYPE = asym_eager_defer_pk
+# Use the vendor-supplied flash-based EEPROM driver that is inside 
+# lib/rdr_lib/librdrcommon.a. Prevent QMK from linking any additional EEPROM 
+# driver to avoid duplicate symbols.
+EEPROM_DRIVER = custom
+
+# The pre-compiled library expects these features to be present.
+RAW_ENABLE            = yes   # provides raw_hid_send()
+VIA_ENABLE            = yes   # enables VIA and Dynamic Keymap
+DYNAMIC_KEYMAP_ENABLE = yes   # explicit for clarity, VIA sets it implicitly
+
+# Miscellaneous board options
+NO_USB_STARTUP_CHECK = yes
+BLUETOOTH_CUSTOM     = yes
+ENCODER_MAP_ENABLE   = yes # Enable ENCODER MAP
+DEBOUNCE_TYPE        = asym_eager_defer_pk


### PR DESCRIPTION
I made the following changes:
- Rename deprecated `EEPROM_CUSTOM` to `EEPROM_DRIVER=custom`
- Define `EEPROM_SIZE=4096` for the custom driver
- Enable `RAW_ENABLE`, `VIA_ENABLE`, `DYNAMIC_KEYMAP_ENABLE` to satisfy librdrcommon.a

Now if you run `qmk compile -kb wob/rd75 -km default` the firmware compiles without errors.